### PR TITLE
feat: add Portainer compose, CI pipeline, and token cache fix

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  time-automation:
+    image: ghcr.io/audioinj/time-automation:latest
+    container_name: time-automation
+    restart: unless-stopped
+    volumes:
+      - time-automation-state:/data
+    environment:
+      - DOMAIN=${DOMAIN}
+      - SUBDOMAIN=${SUBDOMAIN}
+      - USERNAME=${USERNAME}
+      - PASSWORD=${PASSWORD}
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - WORK_DAYS=${WORK_DAYS:-1-5}
+      - START_WORK_MIN=${START_WORK_MIN:-7:30}
+      - START_WORK_MAX=${START_WORK_MAX:-8:30}
+      - START_BREAK_MIN=${START_BREAK_MIN:-11:45}
+      - START_BREAK_MAX=${START_BREAK_MAX:-12:30}
+      - MIN_WORK_DURATION=${MIN_WORK_DURATION:-8.5h}
+      - MAX_WORK_DURATION=${MAX_WORK_DURATION:-9.5h}
+      - MIN_BREAK_DURATION=${MIN_BREAK_DURATION:-0.75h}
+      - MAX_BREAK_DURATION=${MAX_BREAK_DURATION:-1.25h}
+      - TASK=${TASK:-}
+      - HOLIDAY_ADDRESS=${HOLIDAY_ADDRESS:-}
+      - VACATION_ADDRESS=${VACATION_ADDRESS:-}
+      - VACATION_KEYWORD=${VACATION_KEYWORD:-}
+      - VERBOSE=${VERBOSE:-false}
+      - DRY_RUN=${DRY_RUN:-false}
+      - STATE_FILE=/data/state.json
+
+volumes:
+  time-automation-state:

--- a/executor/timeapi.go
+++ b/executor/timeapi.go
@@ -138,7 +138,17 @@ func (e *Executor) post(status interface{}) {
 		if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			break
 		}
-		log.Printf("[POST] Attempt %d failed: %v", attempt, err)
+		if err == nil && resp.StatusCode == 401 {
+			log.Printf("[POST] Attempt %d: token expired (401), re-authenticating...", attempt)
+			e.token = ""
+			e.token = e.login()
+			if e.token == "" {
+				log.Println("[POST] Re-authentication failed, aborting")
+				return
+			}
+		} else {
+			log.Printf("[POST] Attempt %d failed: %v", attempt, err)
+		}
 		time.Sleep(1 * time.Second)
 	}
 	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {


### PR DESCRIPTION
- Add docker-compose.yml with named volume for state persistence at /data
- Add .github/workflows/docker-build.yml to build and push to ghcr.io on main
- Fix token cache in executor: on 401 response, clear and re-authenticate so stale tokens are refreshed automatically within the retry loop

https://claude.ai/code/session_012jqk86rY72wSgzKqAdxkoH